### PR TITLE
Chore: include go-generate buildpack

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,5 +27,4 @@ jobs:
 
     - name: Create Builder Image
       run: |
-        pack builder create builder --config builder.toml --pull-policy if-not-present
-
+        make build-builder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Create Builder Image
       run: |
-        pack builder create builder --config builder.toml
+        make build-builder
 
     - name: Push builder
       env:

--- a/.github/workflows/update-buildpack-tomls.yml
+++ b/.github/workflows/update-buildpack-tomls.yml
@@ -1,0 +1,59 @@
+name: Update buildpack.toml
+
+on:
+  schedule:
+  - cron: '1 6 * * *' # daily at 06:01 UTC
+  workflow_dispatch: {}
+
+concurrency: buildpack_update
+
+jobs:
+  update-buildpack-toml:
+    runs-on: ubuntu-22.04
+    name: Update buildpack.toml
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Checkout Branch
+      uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+      with:
+        branch: automation/buildpack.toml/update
+
+    - name: Update buildpack.toml for meta/go
+      id: update
+      uses: paketo-buildpacks/github-config/actions/buildpack/update@main
+      with:
+        buildpack_toml_path: meta/go/buildpack.toml
+        package_toml_path: meta/go/package.toml
+
+    - name: Commit
+      id: commit
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Updating buildpacks in buildpack.toml"
+        pathspec: "."
+
+    - name: Push Branch
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: automation/buildpack.toml/update
+
+    - name: Open Pull Request (no semver label)
+      if: ${{ steps.commit.outputs.commit_sha != ''  && steps.update.outputs.semver_bump == '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: "Updates buildpacks in buildpack.toml"
+        branch: automation/buildpack.toml/update
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' && steps.update.outputs.semver_bump != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: "Updates buildpacks in buildpack.toml"
+        branch: automation/buildpack.toml/update
+        label: "semver:${{ steps.update.outputs.semver_bump }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+meta/*/buildpack.cnb

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@
 
 EXAMPLES_DIR=../runway-examples/content
 
-build:
+META_BUILDPACKS=$(patsubst %, %buildpack.cnb, $(wildcard meta/*/))
+
+build: $(META_BUILDPACKS)
 	docker build -t r.planetary-quantum.com/runway-public/runway-runimage:jammy-full ./runimage
 	pack builder create builder --config builder.toml --pull-policy if-not-present
+
+meta/%/buildpack.cnb: meta/%/*
+	pack buildpack package $@ --config meta/$*/package.toml --format file --pull-policy if-not-present
 
 test: $(patsubst $(EXAMPLES_DIR)/%/, test-%, $(wildcard $(EXAMPLES_DIR)/*/))
 show-tests:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,14 @@ EXAMPLES_DIR=../runway-examples/content
 
 META_BUILDPACKS=$(patsubst %, %buildpack.cnb, $(wildcard meta/*/))
 
-build: $(META_BUILDPACKS)
+build: build-builder
 	docker build -t r.planetary-quantum.com/runway-public/runway-runimage:jammy-full ./runimage
-	pack builder create builder --config builder.toml --pull-policy if-not-present
 
-meta/%/buildpack.cnb: meta/%/*
-	pack buildpack package $@ --config meta/$*/package.toml --format file --pull-policy if-not-present
+build-builder: $(META_BUILDPACKS)
+	pack -v builder create builder --config builder.toml --pull-policy if-not-present
+
+meta/%/buildpack.cnb: meta/%/*.toml
+	pack -v buildpack package $@ --config meta/$*/package.toml --format file --pull-policy if-not-present
 
 test: $(patsubst $(EXAMPLES_DIR)/%/, test-%, $(wildcard $(EXAMPLES_DIR)/*/))
 show-tests:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ https://github.com/paketo-buildpacks/builder-jammy-full
 
 builder.toml docs: https://buildpacks.io/docs/reference/config/builder-config/
 
+The `meta/` directory holds ["meta"/composite buildpacks](https://buildpacks.io/docs/for-buildpack-authors/concepts/composite-buildpack/),
+when we needed to patch them. But most are directly from upstream.
+
 On **git tags**, this pushes:
 
 * `r.planetary-quantum.com/runway-public/runway-buildpack-stack:jammy-full`

--- a/builder.toml
+++ b/builder.toml
@@ -5,8 +5,8 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
   version = "1.0.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/go:4.12.6"
-  version = "4.12.6"
+  uri = "meta/go/buildpack.cnb"
+  version = "4.12.6-runway1"
 
 [[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/java-native-image:11.2.0"
@@ -58,8 +58,8 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
 [[order]]
 
   [[order.group]]
-    id = "paketo-buildpacks/go"
-    version = "4.12.6"
+    id = "runway-buildpacks/go"
+    version = "4.12.6-runway1"
 
 [[order]]
 

--- a/meta/go/buildpack.toml
+++ b/meta/go/buildpack.toml
@@ -41,6 +41,10 @@ api = "0.7"
     version = "1.0.44"
 
   [[order.group]]
+    id = "paketo-community/go-generate"
+    version = "0.2.36"
+
+  [[order.group]]
     id = "paketo-buildpacks/go-build"
     version = "2.2.17"
 
@@ -79,6 +83,10 @@ api = "0.7"
     id = "paketo-buildpacks/git"
     optional = true
     version = "1.0.27"
+
+  [[order.group]]
+    id = "paketo-community/go-generate"
+    version = "0.2.36"
 
   [[order.group]]
     id = "paketo-buildpacks/go-build"

--- a/meta/go/buildpack.toml
+++ b/meta/go/buildpack.toml
@@ -42,6 +42,7 @@ api = "0.7"
 
   [[order.group]]
     id = "paketo-community/go-generate"
+    optional = true
     version = "0.2.36"
 
   [[order.group]]
@@ -86,6 +87,7 @@ api = "0.7"
 
   [[order.group]]
     id = "paketo-community/go-generate"
+    optional = true
     version = "0.2.36"
 
   [[order.group]]

--- a/meta/go/buildpack.toml
+++ b/meta/go/buildpack.toml
@@ -1,0 +1,100 @@
+api = "0.7"
+
+[buildpack]
+  description = "A buildpack for building Go applications"
+  homepage = "https://github.com/paketo-buildpacks/go"
+  id = "runway-buildpacks/go"
+  keywords = ["go", "golang"]
+  name = "Runway version of the Paketo Buildpack for Go"
+  version = "4.12.6-runway1"
+
+  [[buildpack.licenses]]
+    type = "Apache-2.0"
+    uri = "https://github.com/paketo-buildpacks/go/blob/main/LICENSE"
+
+[metadata]
+  include-files = ["buildpack.toml"]
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/ca-certificates"
+    optional = true
+    version = "3.8.6"
+
+  [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "3.3.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/go-dist"
+    version = "2.6.8"
+
+  [[order.group]]
+    id = "paketo-buildpacks/git"
+    optional = true
+    version = "1.0.27"
+
+  [[order.group]]
+    id = "paketo-buildpacks/go-mod-vendor"
+    version = "1.0.44"
+
+  [[order.group]]
+    id = "paketo-buildpacks/go-build"
+    version = "2.2.17"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "5.10.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version = "4.7.3"
+
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "4.7.3"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/ca-certificates"
+    optional = true
+    version = "3.8.6"
+
+  [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "3.3.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/go-dist"
+    version = "2.6.8"
+
+  [[order.group]]
+    id = "paketo-buildpacks/git"
+    optional = true
+    version = "1.0.27"
+
+  [[order.group]]
+    id = "paketo-buildpacks/go-build"
+    version = "2.2.17"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "5.10.1"
+
+  [[order.group]]
+    id = "paketo-buildpacks/environment-variables"
+    optional = true
+    version = "4.7.3"
+
+  [[order.group]]
+    id = "paketo-buildpacks/image-labels"
+    optional = true
+    version = "4.7.3"

--- a/meta/go/package.toml
+++ b/meta/go/package.toml
@@ -1,0 +1,29 @@
+[buildpack]
+  uri = "./"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/ca-certificates@3.8.6"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/environment-variables@4.7.3"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/git@1.0.27"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/go-build@2.2.17"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/go-dist@2.6.8"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/go-mod-vendor@1.0.44"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/image-labels@4.7.3"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/procfile@5.10.1"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/watchexec@3.3.0"

--- a/meta/go/package.toml
+++ b/meta/go/package.toml
@@ -27,3 +27,6 @@
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/watchexec@3.3.0"
+
+[[dependencies]]
+  uri = "https://github.com/paketo-community/go-generate/releases/download/v0.2.36/go-generate-0.2.36.cnb"


### PR DESCRIPTION
* [x] make actually work
* [x] include go-generate buildpack at the appropriate places inside meta/go buildpack
* [x] include meta buildpack in automatic updates 

no fancy auto-detection or anything for now - this will need at least `runway config set BP_GO_GENERATE=true`, as described in https://github.com/paketo-community/go-generate

* [x] try this out by hand