### PR TITLE
Fix: don't use version suffix ("prerelease") for go buildpack

### DIFF
--- a/.github/workflows/update-buildpack-tomls.yml
+++ b/.github/workflows/update-buildpack-tomls.yml
@@ -28,6 +28,9 @@ jobs:
         buildpack_toml_path: meta/go/buildpack.toml
         package_toml_path: meta/go/package.toml
 
+    - name: Increase version in buildpack.toml for meta/go
+      run: ./scripts/increase-version.sh ./meta/go/buildpack.toml
+
     - name: Commit
       id: commit
       uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main

--- a/meta/go/buildpack.toml
+++ b/meta/go/buildpack.toml
@@ -6,7 +6,7 @@ api = "0.7"
   id = "runway-buildpacks/go"
   keywords = ["go", "golang"]
   name = "Runway version of the Paketo Buildpack for Go"
-  version = "4.12.6-runway-2"
+  version = "4.12.7"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"

--- a/scripts/increase-version.sh
+++ b/scripts/increase-version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+FILE=$1
+
+echo updating "$FILE"
+VERSION=`cat "$FILE" | sed -nE 's/ *version = "(.*)"/\1/p' | head -n 1`
+NEXT_VERSION=`echo "$VERSION" | awk -F. -v OFS=. '{$NF += 1 ; print}'`
+echo updating from "$VERSION" to "$NEXT_VERSION"
+# NOTE: this only works with GNU sed, macOS sed needs: sed -i '' 's/version ....
+sed -i 's/version = "'$VERSION'"/version = "'$NEXT_VERSION'"/' "$FILE"
+echo DONE


### PR DESCRIPTION
This is to make auto-updates work. Instead, we now increase the buildpack version every time it updates - and then the *builder* update should pick that up.