### PR TITLE
Fix static buildpack inclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ test-%: FORCE
         --verbose --pull-policy if-not-present
 FORCE:
 
-test-docker test-hugo test-jekyll test-ruby test-README.md.m4:
+test-docker test-jekyll test-ruby test-README.md.m4:
 	@echo "ignored (does not use buildpacks)"

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,11 @@ test-%: FORCE
         --verbose --pull-policy if-not-present
 FORCE:
 
+test-hugo: FORCE # (needs env vars, set by builder in real life)
+	pack build runway-buildpack-test --path "$(EXAMPLES_DIR)/hugo" \
+		--env BP_WEB_SERVER_ROOT=./ --env BP_WEB_SERVER=nginx \
+		--builder builder \
+        --verbose --pull-policy if-not-present
+
 test-docker test-jekyll test-ruby test-README.md.m4:
 	@echo "ignored (does not use buildpacks)"

--- a/builder.toml
+++ b/builder.toml
@@ -92,6 +92,28 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
 [[order]]
 
   [[order.group]]
+    id = "paketo-buildpacks/nginx"
+    version = "0.17.24"
+    optional = true
+
+  [[order.group]]
+    id = "static-buildpack"
+    version = "0.1.1"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/httpd"
+    version = "0.7.48"
+    optional = true
+
+  [[order.group]]
+    id = "static-buildpack"
+    version = "0.1.1"
+
+[[order]]
+
+  [[order.group]]
     id = "paketo-buildpacks/web-servers"
     version = "1.4.2"
 
@@ -118,28 +140,6 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
   [[order.group]]
     id = "paketo-buildpacks/procfile"
     version = "5.11.0"
-
-[[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/nginx"
-    version = "0.17.24"
-    optional = true
-
-  [[order.group]]
-    id = "static-buildpack"
-    version = "0.1.1"
-
-[[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/httpd"
-    version = "0.7.48"
-    optional = true
-
-  [[order.group]]
-    id = "static-buildpack"
-    version = "0.1.1"
 
 [[order]]
 

--- a/builder.toml
+++ b/builder.toml
@@ -122,12 +122,6 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
 [[order]]
 
   [[order.group]]
-    id = "deno-buildpack"
-    version = "0.4.0"
-
-[[order]]
-
-  [[order.group]]
     id = "paketo-buildpacks/nginx"
     version = "0.17.24"
     optional = true
@@ -146,6 +140,12 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
   [[order.group]]
     id = "static-buildpack"
     version = "0.1.1"
+
+[[order]]
+
+  [[order.group]]
+    id = "deno-buildpack"
+    version = "0.4.0"
 
 [stack]
   build-image = "docker.io/paketobuildpacks/build-jammy-full:0.1.76"


### PR DESCRIPTION
for https://github.com/pngmbh/issues/issues/1959

with `BP_WEB_SERVER=nginx` set, this needs to be before paketo/webservers, because otherwise that one wins