### PR TITLE
update(ci): use our own gh app to run all workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,5 +159,14 @@ jobs:
     needs: [runimage, builder]
     runs-on: ubuntu-latest
     steps:
+    - id: generate-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ secrets.RUNWAY_CI_BOT_APP_ID }}
+        private-key: ${{ secrets.RUNWAY_CI_BOT_PRIVATE_KEY }}
     - uses: actions/checkout@v5
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
     - uses: softprops/action-gh-release@v2
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -16,5 +16,12 @@ jobs:
       issues: write
       contents: read
     steps:
+      - id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RUNWAY_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.RUNWAY_CI_BOT_PRIVATE_KEY }}
       - name: Notify release
         uses: nearform-actions/github-action-notify-release@v1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-builder-toml.yml
+++ b/.github/workflows/update-builder-toml.yml
@@ -12,8 +12,15 @@ jobs:
     name: Update builder.toml
     runs-on: ubuntu-22.04
     steps:
+    - id: generate-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ secrets.RUNWAY_CI_BOT_APP_ID }}
+        private-key: ${{ secrets.RUNWAY_CI_BOT_PRIVATE_KEY }}
     - name: Check out
       uses: actions/checkout@v5
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Checkout branch
       uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
@@ -47,6 +54,6 @@ jobs:
       if: ${{ steps.commit.outputs.commit_sha != '' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/open@main
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.generate-token.outputs.token }}
         title: "Updating builder.toml"
         branch: "automation/builder-toml"

--- a/.github/workflows/update-buildpack-tomls.yml
+++ b/.github/workflows/update-buildpack-tomls.yml
@@ -15,8 +15,14 @@ jobs:
         buildpack: [dotnet-core, go, java, java-native-image, nodejs, php, ruby, runway]
     runs-on: ubuntu-latest
     steps:
-
+    - id: generate-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ secrets.RUNWAY_CI_BOT_APP_ID }}
+        private-key: ${{ secrets.RUNWAY_CI_BOT_PRIVATE_KEY }}
     - uses: actions/checkout@v5
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
 
     - id: names
       run: |
@@ -43,7 +49,7 @@ jobs:
     - id: commit
       uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
       with:
-        message: "chore(deps): update buildpacks in ${{ steps.names.outputs.toml }}"
+        message: "update(${{ matrix.buildpack }}): update dependencies in ${{ steps.names.outputs.toml }}"
         pathspec: "."
 
     - if: ${{ steps.commit.outputs.commit_sha != '' && steps.update.outputs.semver_bump != '<none>'}}
@@ -54,7 +60,7 @@ jobs:
     - if: ${{ steps.commit.outputs.commit_sha != '' && steps.update.outputs.semver_bump != '<none>' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/open@main
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.generate-token.outputs.token }}
         title: "chore(deps): buildpacks in ${{ steps.names.outputs.toml }}"
         branch: ${{ steps.names.outputs.branch }}
         label: "semver:${{ steps.update.outputs.semver_bump }}"


### PR DESCRIPTION
this is necessary so the PRs to update the composite buildpacks or
the builder, also trigger the workflows we have setup. additionally
it looks a little nicer for the release etc..
