### PR TITLE
chore(ci): split/optimize workflows

### DIFF
--- a/.github/workflows/check-meta.yml
+++ b/.github/workflows/check-meta.yml
@@ -2,6 +2,10 @@ name: meta
 
 on:
   pull_request:
+    paths:
+      - 'meta/**'
+      - 'Makefile'
+      - '.github/workflows/check-meta.yml'
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 
 on:
   pull_request:
+    paths:
+      - 'builders/**'
+      - 'Makefile'
+      - '.github/workflows/release.yml'
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
release.yml (runimage + builder) now only runs on PRs touching
builders/**, Makefile, or the workflow itself. tag pushes still
build everything.

check-meta.yml only runs on PRs touching meta/**, Makefile, or the
workflow itself.
